### PR TITLE
Adjust to support new SDK versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.9
+
+* Bump Android to 2.0.3
+* Bump iOS to 0.4.6
+
 ## 0.1.8
 
 * Bump Android to 2.0.2

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
         // The message to display when the limit has been reached. (Android only)
         ImageLimitReachedMessage: "You have reached the image limit",
 
-        // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+        // The threshold sensitive the motion detection is. (lower value is higher sensitivity, default 50).
         ImageMovingSensitivityAndroid: 50,
         
         // Optional. Only affects iOS.
@@ -185,7 +185,7 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
         // Whether the camera automatically saves the images to the camera roll. Default true. (iOS version 0.4.2 and up only)
         StoreImagesToCameraRoll: true,
 
-        // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+        // The threshold sensitive the motion detection is. (lower value is higher sensitivity, default 200).
         ImageMovingSensitivityiOS: 200,
     });
 });

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ target 'YourApplicationName' do
   # Pods for YourApplicationName
   // ... other pods
 
-  pod 'Klippa-Scanner', podspec: 'https://custom-ocr.klippa.com/sdk/ios/specrepo/{your-username}/{your-password}/KlippaScanner/0.4.5.podspec'
+  pod 'Klippa-Scanner', podspec: 'https://custom-ocr.klippa.com/sdk/ios/specrepo/{your-username}/{your-password}/KlippaScanner/0.4.6.podspec'
 end
 ```
 
@@ -87,6 +87,9 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
     
         // Whether the "multi-document-mode" should be enabled by default.
         DefaultMultipleDocuments: true,
+
+        // Ability to disable/hide the shutter button (only works when a model is supplied as well).
+        ShutterButton: {allowShutterButton: true, hideShutterButton: false},
     
         // Whether the crop mode (auto edge detection) should be enabled by default.
         DefaultCrop: true,
@@ -100,6 +103,9 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
     
         // The warning message when someone should move closer to a document, should be a string.
         MoveCloserMessage: "Move closer to the document",
+
+        // The warning message when the camera preview has to much motion to be able to automatically take a photo.
+        ImageMovingMessage: "Too much movement", 
     
         // Optional. Only affects Android.
     
@@ -117,10 +123,10 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
         
         // The message to display when the limit has been reached. (Android only)
         ImageLimitReachedMessage: "You have reached the image limit",
+
+        // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+        ImageMovingSensitivityAndroid: 50,
         
-        // The warning message when the camera preview has to much motion to be able to automatically take a photo.
-        ImageMovingMessage: "Too much movement", 
-    
         // Optional. Only affects iOS.
         // The warning message when the camera result is too bright.
         ImageTooBrightMessage: "The image is too bright",
@@ -178,6 +184,9 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
 
         // Whether the camera automatically saves the images to the camera roll. Default true. (iOS version 0.4.2 and up only)
         StoreImagesToCameraRoll: true,
+
+        // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+        ImageMovingSensitivityiOS: 200,
     });
 });
 ```
@@ -238,7 +247,7 @@ Replace the `{version}` value with the version you want to use.
 
 ### iOS
 
-Edit the file `ios/Podfile`, change the pod line of `Klippa-Scanner` and replace `0.4.3.podspec` with `{version}.podspec`, replace the `{version}` value with the version you want to use.
+Edit the file `ios/Podfile`, change the pod line of `Klippa-Scanner` and replace `0.4.6.podspec` with `{version}.podspec`, replace the `{version}` value with the version you want to use.
 
 ## How to change the colors of the scanner?
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ repositories {
 }
 
 dependencies {
-    def klippaScannerVersion = project.hasProperty('klippaScannerVersion') ? project.klippaScannerVersion : "2.0.2"
+    def klippaScannerVersion = project.hasProperty('klippaScannerVersion') ? project.klippaScannerVersion : "2.0.3"
 
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules

--- a/android/src/main/java/com/klippa/reactscanner/KlippaScannerSDKModule.java
+++ b/android/src/main/java/com/klippa/reactscanner/KlippaScannerSDKModule.java
@@ -203,6 +203,17 @@ public class KlippaScannerSDKModule extends ReactContextBaseJavaModule {
                 cameraIntent.putExtra(com.klippa.scanner.KlippaScanner.PREVIEW_DURATION, config.getDouble("PreviewDuration"));
             }
 
+            if (config.hasKey("ShutterButton")) {
+                if (config.getMap("ShutterButton").hasKey("allowShutterButton") && config.getMap("ShutterButton").hasKey("hideShutterButton")) {
+                    cameraIntent.putExtra(com.klippa.scanner.KlippaScanner.ALLOW_SHUTTER_BUTTON, config.getMap("ShutterButton").getBoolean("allowShutterButton"));
+                    cameraIntent.putExtra(com.klippa.scanner.KlippaScanner.HIDE_SHUTTER_BUTTON, config.getMap("ShutterButton").getBoolean("hideShutterButton"));
+                }
+            }
+
+            if (config.hasKey("ImageMovingSensitivityAndroid")) {
+                cameraIntent.putExtra(com.klippa.scanner.KlippaScanner.IMAGE_MOVING_SENSITIVITY, config.getInt("ImageMovingSensitivityAndroid"));
+            }
+
             currentActivity.startActivityForResult(cameraIntent, CAMERA_REQUEST_CODE);
         } catch (Exception e) {
             mCameraPromise.reject(E_FAILED_TO_SHOW_CAMERA, e);

--- a/ios/KlippaScannerSDK.m
+++ b/ios/KlippaScannerSDK.m
@@ -214,6 +214,19 @@ RCT_EXPORT_METHOD(getCameraResult:(NSDictionary *)config getCameraResultWithReso
         KlippaScanner.setup.storeImagesToCameraRoll = YES;
     }
 
+    if ([config objectForKey:@"ShutterButton"]) {
+        if ([[config objectForKey:@"ShutterButton"] objectForKey:@"allowShutterButton"]) {
+            KlippaScanner.setup.allowShutterButton = [[[config objectForKey:@"ShutterButton"] objectForKey:@"allowShutterButton"] boolValue];
+        }
+        if ([[config objectForKey:@"ShutterButton"] objectForKey:@"hideShutterButton"]) {
+            KlippaScanner.setup.hideShutterButton = [[[config objectForKey:@"ShutterButton"] objectForKey:@"hideShutterButton"] boolValue];
+        }
+    }
+
+    if ([config objectForKey:@"ImageMovingSensitivityiOS"]) {
+        KlippaScanner.setup.ImageMovingSensitivity = [[config objectForKey:@"ImageMovingSensitivityiOS"] floatValue];
+    }
+
     UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
 
     if ([config objectForKey:@"Model"]) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@klippa/react-native-klippa-scanner-sdk",
   "title": "React Native Klippa Scanner SDK",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Allows you to take pictures with the Klippa Scanner SDK from React Native.",
   "main": "index.js",
   "files": [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -101,7 +101,7 @@ export class CameraConfig {
   ImageLimitReachedMessage?: string;
   OutputFilename?: string;
 
-  // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+  // The threshold sensitive the motion detection is. (lower value is higher sensitivity, default 50).
   ImageMovingSensitivityAndroid?: number;
 
   // iOS options.
@@ -144,7 +144,7 @@ export class CameraConfig {
   // Whether the camera has a view finder overlay (a helper grid so the user knows where the document should be), should be a Boolean.
   IsViewFinderEnabled?: boolean;
 
-  // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+  // The threshold sensitive the motion detection is. (lower value is higher sensitivity, default 200).
   ImageMovingSensitivityiOS?: number;
 
   // Whether the camera automatically saves the images to the camera roll. Default true. (iOS version 0.4.2 and up only)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,13 @@ export interface SuccessOptions {
   previewDuration: number;
 }
 
+export interface ShutterButton {
+  // Whether to allow or disallow the shutter button to work (can only be disabled if a model is supplied)
+  allowShutterButton: boolean;
+  // Whether the shutter button should be hidden (only works if allowShutterButton is false)
+  hideShutterbutton: boolean;
+}
+
 
 export class CameraConfig {
   // Global options.
@@ -64,6 +71,21 @@ export class CameraConfig {
   // The amount of seconds the preview should be visible for, should be a float.
   PreviewDuration?: number;
 
+  // If you would like to use a custom model for object detection. Model + labels file should be packaged in your bundle.
+  Model?: ModelOptions;
+
+  // If you would like to enable automatic capturing of images.
+  Timer?: TimerOptions;
+
+  // To add extra horizontal and / or vertical padding to the cropped image.
+  CropPadding?: Dimensions;
+
+  // After capture, show a checkmark preview with this success message, instead of a preview of the image.
+  Success?: SuccessOptions;
+
+  // Whether to disable/hide the shutterbutton (only works if a model is supplied).
+  ShutterButton?: ShutterButton;
+
   // Android options.
 
   // Where to put the image results.
@@ -78,6 +100,9 @@ export class CameraConfig {
   // The message to display when the limit has been reached.
   ImageLimitReachedMessage?: string;
   OutputFilename?: string;
+
+  // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+  ImageMovingSensitivityAndroid?: number;
 
   // iOS options.
 
@@ -119,13 +144,8 @@ export class CameraConfig {
   // Whether the camera has a view finder overlay (a helper grid so the user knows where the document should be), should be a Boolean.
   IsViewFinderEnabled?: boolean;
 
-  Model?: ModelOptions;
-
-  Timer?: TimerOptions;
-
-  CropPadding?: Dimensions;
-
-  Success?: SuccessOptions;
+  // The threshold sensitive the motion detection is. (lower value is higher sensitivity).
+  ImageMovingSensitivityiOS?: number;
 
   // Whether the camera automatically saves the images to the camera roll. Default true. (iOS version 0.4.2 and up only)
   StoreImagesToCameraRoll?: boolean;


### PR DESCRIPTION
This PR includes the changes to support the newest iOS and Android SDK's.

Users can now use the following:

```
ShutterButton: {allowShutterButton: true, hideShutterButton: false},
```
This allows the users to disallow (greyed out shutter button) or hide the shutter button (gone completely)

Also able to adjust the motion detection sensitivity per OS.

### iOS:

```
ImageMovingSensitivityiOS: 200,
```

### Android:

```
ImageMovingSensitivityAndroid: 50,
```

This is necessary because they each use their own methods which work in different ways. Essentially they work the same, low value is higher motion sensitive.