### PR TITLE
Upgrade to support Android 2.0.6 and iOS 0.4.10 of KlippaScanner SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.10
+
+* Bump Android to 2.0.6
+* Bump iOS to 0.4.10
+
 ## 0.1.9
 
 * Bump Android to 2.0.3

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ target 'YourApplicationName' do
   # Pods for YourApplicationName
   // ... other pods
 
-  pod 'Klippa-Scanner', podspec: 'https://custom-ocr.klippa.com/sdk/ios/specrepo/{your-username}/{your-password}/KlippaScanner/0.4.6.podspec'
+  pod 'Klippa-Scanner', podspec: 'https://custom-ocr.klippa.com/sdk/ios/specrepo/{your-username}/{your-password}/KlippaScanner/0.4.10.podspec'
 end
 ```
 
@@ -106,6 +106,12 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
 
         // The warning message when the camera preview has to much motion to be able to automatically take a photo.
         ImageMovingMessage: "Too much movement", 
+
+        // To limit the amount of images that can be taken.
+        ImageLimit: 10,
+        
+        // The message to display when the limit has been reached.
+        ImageLimitReachedMessage: "You have reached the image limit",
     
         // Optional. Only affects Android.
     
@@ -118,12 +124,6 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
         // The filename to use for the output images, supports replacement tokens %dateTime% and %randomUUID%.
         OutputFilename: "KlippaScannerExample-%dateTime%-%randomUUID%",
     
-        // To limit the amount of images that can be taken. (Android only)
-        ImageLimit: 10,
-        
-        // The message to display when the limit has been reached. (Android only)
-        ImageLimitReachedMessage: "You have reached the image limit",
-
         // The threshold sensitive the motion detection is. (lower value is higher sensitivity, default 50).
         ImageMovingSensitivityAndroid: 50,
         
@@ -179,7 +179,7 @@ KlippaScannerSDK.getCameraPermission().then((authStatus) => {
         // To add extra horizontal and / or vertical padding to the cropped image.
         CropPadding: {width: 100, height: 100},
 
-        // After capture, show a checkmark preview with this success message, instead of a preview of the image.
+        // After capture, show a check mark preview with this success message, instead of a preview of the image.
         Success: {message: "Success!", previewDuration: 0.3},
 
         // Whether the camera automatically saves the images to the camera roll. Default true. (iOS version 0.4.2 and up only)
@@ -247,7 +247,7 @@ Replace the `{version}` value with the version you want to use.
 
 ### iOS
 
-Edit the file `ios/Podfile`, change the pod line of `Klippa-Scanner` and replace `0.4.6.podspec` with `{version}.podspec`, replace the `{version}` value with the version you want to use.
+Edit the file `ios/Podfile`, change the pod line of `Klippa-Scanner` and replace `0.4.10.podspec` with `{version}.podspec`, replace the `{version}` value with the version you want to use.
 
 ## How to change the colors of the scanner?
 
@@ -270,7 +270,7 @@ Add or edit the file `android/app/src/main/res/values/colors.xml`, add the follo
 ```
 
 ### iOS
-Use the following properties in the config when running `getCameraResult`: `PrimaryColor`, `AccentColor`, `OverlayColor`, `WarningBackgroundColor`, `WarningTextColor`, `OverlayColorAlpha`, 'IconDisabledColor', `IconEnabledColor`,  `ReviewIconColor`.
+Use the following properties in the config when running `getCameraResult`: `PrimaryColor`, `AccentColor`, `OverlayColor`, `WarningBackgroundColor`, `WarningTextColor`, `OverlayColorAlpha`, `IconDisabledColor`, `IconEnabledColor`,  `ReviewIconColor`.
 
 ## Important iOS notes
 Older iOS versions do not ship the Swift libraries. To make sure the SDK works on older iOS versions, you can configure the build to embed the Swift libraries using the build setting `EMBEDDED_CONTENT_CONTAINS_SWIFT = YES`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ repositories {
 }
 
 dependencies {
-    def klippaScannerVersion = project.hasProperty('klippaScannerVersion') ? project.klippaScannerVersion : "2.0.3"
+    def klippaScannerVersion = project.hasProperty('klippaScannerVersion') ? project.klippaScannerVersion : "2.0.6"
 
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules

--- a/android/src/main/java/com/klippa/reactscanner/KlippaScannerSDKModule.java
+++ b/android/src/main/java/com/klippa/reactscanner/KlippaScannerSDKModule.java
@@ -50,10 +50,12 @@ public class KlippaScannerSDKModule extends ReactContextBaseJavaModule {
                         ArrayList<com.klippa.scanner.object.Image> imageList = intent.getParcelableArrayListExtra(com.klippa.scanner.KlippaScanner.IMAGES);
                         boolean multipleDocuments = intent.getBooleanExtra(com.klippa.scanner.KlippaScanner.CREATE_MULTIPLE_RECEIPTS, false);
                         boolean crop = intent.getBooleanExtra(com.klippa.scanner.KlippaScanner.CROP, false);
+                        boolean timerEnabled = intent.getBooleanExtra(com.klippa.scanner.KlippaScanner.TIMER_ENABLED, false);
                         String color = intent.getStringExtra(com.klippa.scanner.KlippaScanner.COLOR);
 
                         map.putBoolean("MultipleDocuments", multipleDocuments);
                         map.putBoolean("Crop", crop);
+                        map.putBoolean("TimerEnabled", timerEnabled);
                         map.putString("Color", color);
 
                         for (int i = 0; i < imageList.size(); i++) {
@@ -174,6 +176,9 @@ public class KlippaScannerSDKModule extends ReactContextBaseJavaModule {
             }
 
             if (config.hasKey("Timer")) {
+                if (config.getMap("Timer").hasKey("allowed")) {
+                    cameraIntent.putExtra(com.klippa.scanner.KlippaScanner.ALLOW_TIMER, config.getMap("Timer").getBoolean("allowed"));
+                }
                 if (config.getMap("Timer").hasKey("enabled")) {
                     cameraIntent.putExtra(com.klippa.scanner.KlippaScanner.TIMER_ENABLED, config.getMap("Timer").getBoolean("enabled"));
                 }

--- a/ios/KlippaScannerSDK.m
+++ b/ios/KlippaScannerSDK.m
@@ -338,13 +338,21 @@ RCT_EXPORT_METHOD(getCameraResult:(NSDictionary *)config getCameraResultWithReso
         multipleDocuments = [NSNumber numberWithBool:YES];
     }
 
+    NSNumber *cropEnabled = [NSNumber numberWithBool:NO];
+    if (result.cropEnabled) {
+        cropEnabled = [NSNumber numberWithBool:YES];
+    }
+
     NSNumber *timerEnabled = [NSNumber numberWithBool:NO];
     if (result.timerEnabled) {
         timerEnabled = [NSNumber numberWithBool:YES];
     }
 
     NSDictionary *resultDict = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                images, @"Images", multipleDocuments, @"MultipleDocuments", timerEnabled, @"TimerEnabled", nil];
+                                images, @"Images", 
+                                multipleDocuments, @"MultipleDocuments", 
+                                cropEnabled, @"Crop", 
+                                timerEnabled, @"TimerEnabled", nil];
 
     if (_resolvePromise != nil) {
         _resolvePromise(resultDict);

--- a/ios/KlippaScannerSDK.m
+++ b/ios/KlippaScannerSDK.m
@@ -110,6 +110,19 @@ RCT_EXPORT_METHOD(getCameraResult:(NSDictionary *)config getCameraResultWithReso
         KlippaScanner.setup.imageTooDarkMessage = @"";
     }
 
+    if ([config objectForKey:@"ImageLimitReachedMessage"]) {
+        KlippaScanner.setup.imageLimitReachedMessage = [config objectForKey:@"ImageLimitReachedMessage"];
+        
+    } else {
+        KlippaScanner.setup.imageLimitReachedMessage = @"";
+    }
+
+    if ([config objectForKey:@"ImageLimit"]) {
+        KlippaScanner.setup.imageLimit = [[config objectForKey:@"ImageLimit"] intValue];
+    } else {
+        KlippaScanner.setup.imageLimit = 0;
+    }
+
     if ([config objectForKey:@"ImageMovingMessage"]) {
         KlippaScanner.setup.imageMovingMessage = [config objectForKey:@"ImageMovingMessage"];
     } else {
@@ -183,6 +196,9 @@ RCT_EXPORT_METHOD(getCameraResult:(NSDictionary *)config getCameraResultWithReso
     }
 
     if ([config objectForKey:@"Timer"]) {
+        if ([[config objectForKey:@"Timer"] objectForKey:@"allowed"]) {
+            KlippaScanner.setup.allowTimer = [[[config objectForKey:@"Timer"] objectForKey:@"allowed"] boolValue];
+        }
         if ([[config objectForKey:@"Timer"] objectForKey:@"enabled"]) {
             KlippaScanner.setup.isTimerEnabled = [[[config objectForKey:@"Timer"] objectForKey:@"enabled"] boolValue];
         }
@@ -236,7 +252,6 @@ RCT_EXPORT_METHOD(getCameraResult:(NSDictionary *)config getCameraResultWithReso
         if ([[config objectForKey:@"Model"] objectForKey:@"labelsName"]) {
             KlippaScanner.setup.modelLabels = [[config objectForKey:@"Model"] objectForKey:@"labelsName"];
         }
-        KlippaScanner.setup.modelViewController = rootViewController;
         KlippaScanner.setup.runWithModel = YES;
     }
 
@@ -323,8 +338,13 @@ RCT_EXPORT_METHOD(getCameraResult:(NSDictionary *)config getCameraResultWithReso
         multipleDocuments = [NSNumber numberWithBool:YES];
     }
 
+    NSNumber *timerEnabled = [NSNumber numberWithBool:NO];
+    if (result.timerEnabled) {
+        timerEnabled = [NSNumber numberWithBool:YES];
+    }
+
     NSDictionary *resultDict = [[NSDictionary alloc] initWithObjectsAndKeys:
-                                images, @"Images", multipleDocuments, @"MultipleDocuments", nil];
+                                images, @"Images", multipleDocuments, @"MultipleDocuments", timerEnabled, @"TimerEnabled", nil];
 
     if (_resolvePromise != nil) {
         _resolvePromise(resultDict);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@klippa/react-native-klippa-scanner-sdk",
   "title": "React Native Klippa Scanner SDK",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Allows you to take pictures with the Klippa Scanner SDK from React Native.",
   "main": "index.js",
   "files": [

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,9 @@ export interface ModelOptions {
 }
 
 export interface TimerOptions {
-  // Whether automatically capturing of images is enabled. Only available when using a custom object detection model.
+  // Whether the timerButton is shown or hidden.
+  allowed: boolean;
+  // Whether automatically capturing of images is enabled.
   enabled: boolean;
   // The duration of the interval (in seconds) in which images are automatically captured, should be a float.
   duration: number;
@@ -20,7 +22,7 @@ export interface Dimensions {
 }
 
 export interface SuccessOptions {
-  // After capture, show a checkmark preview with this success message, instead of a preview of the image.
+  // After capture, show a check mark preview with this success message, instead of a preview of the image.
   message: string;
   // The amount of seconds the success message should be visible for, should be a float.
   previewDuration: number;
@@ -30,7 +32,7 @@ export interface ShutterButton {
   // Whether to allow or disallow the shutter button to work (can only be disabled if a model is supplied)
   allowShutterButton: boolean;
   // Whether the shutter button should be hidden (only works if allowShutterButton is false)
-  hideShutterbutton: boolean;
+  hideShutterButton: boolean;
 }
 
 
@@ -80,11 +82,17 @@ export class CameraConfig {
   // To add extra horizontal and / or vertical padding to the cropped image.
   CropPadding?: Dimensions;
 
-  // After capture, show a checkmark preview with this success message, instead of a preview of the image.
+  // After capture, show a check mark preview with this success message, instead of a preview of the image.
   Success?: SuccessOptions;
 
-  // Whether to disable/hide the shutterbutton (only works if a model is supplied).
+  // Whether to disable/hide the shutter button (only works if a model is supplied).
   ShutterButton?: ShutterButton;
+
+  // To limit the amount of images that can be taken.
+  ImageLimit?: number;
+
+  // The message to display when the limit has been reached.
+  ImageLimitReachedMessage?: string;
 
   // Android options.
 
@@ -94,11 +102,6 @@ export class CameraConfig {
   // What the default color conversion will be (grayscale, original).
   DefaultColor?: 'original' | 'grayscale';
 
-  // To limit the amount of images that can be taken.
-  ImageLimit?: number;
-
-  // The message to display when the limit has been reached.
-  ImageLimitReachedMessage?: string;
   OutputFilename?: string;
 
   // The threshold sensitive the motion detection is. (lower value is higher sensitivity, default 50).
@@ -112,7 +115,7 @@ export class CameraConfig {
   // The warning message when the camera result is too dark.
   ImageTooDarkMessage?: string;
 
-  // The iOS colors to be conigured as RGB Hex. For Android see the readme.
+  // The iOS colors to be configured as RGB Hex. For Android see the readme.
 
   // The primary color of the interface, should be a hex RGB color string.
   PrimaryColor?: string;
@@ -147,7 +150,7 @@ export class CameraConfig {
   // The threshold sensitive the motion detection is. (lower value is higher sensitivity, default 200).
   ImageMovingSensitivityiOS?: number;
 
-  // Whether the camera automatically saves the images to the camera roll. Default true. (iOS version 0.4.2 and up only)
+  // Whether the camera automatically saves the images to the camera roll. Default true. (iOS SDK version 0.4.2 and up only)
   StoreImagesToCameraRoll?: boolean;
 }
 
@@ -157,6 +160,9 @@ export class CameraResult {
 
   // Whether the MultipleDocuments option was turned on, so you can save it as default.
   MultipleDocuments?: boolean;
+
+  // Whether the AllowTimer option was turned on, so you can save it as default.
+  TimerEnabled?: boolean;
 
   // Android only.
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -164,10 +164,10 @@ export class CameraResult {
   // Whether the AllowTimer option was turned on, so you can save it as default.
   TimerEnabled?: boolean;
 
-  // Android only.
-
   // Whether the Crop option was turned on, so you can save it as default.
   Crop?: boolean;
+
+  // Android only.
 
   // What color option was used, so you can save it as default.
   Color?: 'original' | 'grayscale';


### PR DESCRIPTION
This PR includes the changes to support the newest iOS and Android SDK's.

Users can now use the following:

Whether the Timer is allowed, if not it hides the button entirely.
```
Timer: {allowed: true, enabled: true, duration: 0.4},
```

```ImageLimit?: number;``` & ```ImageLimitReachedMessage?: string;``` can now also be used on both Android and iOS.

We also now return whether the Timer was enabled or not so the user can store this in device.
For example:

```
KlippaScannerSDK.getCameraResult({
    License: "your-license",
    Timer: {allowed: true, enabled: true, duration: 0.4},
    ImageLimit: 2,
    ImageLimitReachedMessage: "Limiet bereikt",
}).then((res) => {
    Alert.alert("Timer was enabled " + res.TimerEnabled);
}).catch((rej) => {
   console.log(rej);
    Alert.alert(rej.toString());
})
```
