### PR TITLE
Update to support gradle 7+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+* Added support for gradle 7+
+
 ## 0.1.13
 
 * Bump iOS to 0.4.11

--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ allprojects {
 
 Replace the `{your-username}` and `{your-password}` values with the ones provided by Klippa.
 
+If you're using gradle 7+ you will need to change `copyDownloadableDepsToLibs` in the `app/build.gradle`.
+It should now look like:
+
+```maven
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.implementation
+    into 'libs'
+}
+
+```
+
 ### iOS
 
 Edit the file `ios/Podfile`, add the Klippa CocoaPod:
@@ -195,7 +206,7 @@ The result of `KlippaScannerSDK.getCameraResult()` is a Promise, so you can get 
 ```javascript
 KlippaScannerSDK.getCameraResult(options).then((result) => {
     console.log(result);
-}).reject((reason) => {
+}).catch((reason) => {
     console.log(reason);
 });
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@
 //   - https://github.com/facebook/react-native/blob/0.58-stable/local-cli/templates/HelloWorld/android/app/build.gradle
 
 def DEFAULT_COMPILE_SDK_VERSION = 31
-def DEFAULT_BUILD_TOOLS_VERSION = '29.0.2'
+def DEFAULT_BUILD_TOOLS_VERSION = '30.0.3'
 def DEFAULT_MIN_SDK_VERSION = 21
 def DEFAULT_TARGET_SDK_VERSION = 31
 
@@ -20,7 +20,7 @@ def safeExtGet(prop, fallback) {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 buildscript {
     // The Android Gradle plugin is only required when opening the android folder stand-alone.
@@ -33,13 +33,10 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:4.1.3'
+            classpath 'com.android.tools.build:gradle:7.1.2'
         }
     }
 }
-
-apply plugin: 'com.android.library'
-apply plugin: 'maven'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
@@ -107,13 +104,17 @@ def configureReactNativePom(def pom) {
     }
 }
 
+configurations {
+    klippaConfig.extendsFrom implementation
+}
+
 afterEvaluate { project ->
     // some Gradle build hooks ref:
     // https://www.oreilly.com/library/view/gradle-beyond-the/9781449373801/ch03.html
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+        classpath += files(project.getConfigurations().getByName('klippaConfig').asList())
         include '**/*.java'
     }
 
@@ -142,12 +143,12 @@ afterEvaluate { project ->
         archives androidJavadocJar
     }
 
-    task installArchives(type: Upload) {
-        configuration = configurations.archives
-        repositories.mavenDeployer {
-            // Deploy to react-native-event-bridge/maven, ready to publish to npm
-            repository url: "file://${projectDir}/../android/maven"
-            configureReactNativePom pom
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                artifact androidSourcesJar
+            }
         }
     }
+
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@klippa/react-native-klippa-scanner-sdk",
   "title": "React Native Klippa Scanner SDK",
-  "version": "0.1.13",
+  "version": "0.2.0",
   "description": "Allows you to take pictures with the Klippa Scanner SDK from React Native.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
As per https://docs.gradle.org/3.4/release-notes.html we should now use `implementation` instead of compile. This does also mean that when implementing the SDK users should now use `configurations.implementation` instead of `configurations.compile` in their build.gradle (app).